### PR TITLE
-Fixed ae2 id change and..

### DIFF
--- a/src/main/resources/data/crimsonchickens/configs/modded/ae_charged_quartz.json
+++ b/src/main/resources/data/crimsonchickens/configs/modded/ae_charged_quartz.json
@@ -1,6 +1,6 @@
 {
 	"displayName": "Charged Certus Chicken",
-	"dropItem": "appliedenergistics2:charged_certus_quartz_crystal",
+	"dropItem": "ae2:charged_certus_quartz_crystal",
 	"dropItemNBT": "",
 	"spawnNaturally": false,
 	"spawnType": 1,

--- a/src/main/resources/data/crimsonchickens/configs/modded/ae_quartz.json
+++ b/src/main/resources/data/crimsonchickens/configs/modded/ae_quartz.json
@@ -1,6 +1,6 @@
 {
 	"displayName": "Certus Chicken",
-	"dropItem": "appliedenergistics2:certus_quartz_crystal",
+	"dropItem": "ae2:certus_quartz_crystal",
 	"dropItemNBT": "",
 	"spawnNaturally": false,
 	"spawnType": 1,

--- a/src/main/resources/data/crimsonchickens/configs/modded/draconium.json
+++ b/src/main/resources/data/crimsonchickens/configs/modded/draconium.json
@@ -18,5 +18,5 @@
 	"hasTrait": 0,
 	"parentA": "",
 	"parentB": "",
-	"enabled": true
+	"enabled": false
 }

--- a/src/main/resources/data/crimsonchickens/configs/modded/draconium_awakened.json
+++ b/src/main/resources/data/crimsonchickens/configs/modded/draconium_awakened.json
@@ -18,5 +18,5 @@
 	"hasTrait": 0,
 	"parentA": "",
 	"parentB": "",
-	"enabled": true
+	"enabled": false
 }

--- a/src/main/resources/data/crimsonchickens/configs/modded/dust.json
+++ b/src/main/resources/data/crimsonchickens/configs/modded/dust.json
@@ -18,5 +18,5 @@
 	"hasTrait": 0,
 	"parentA": "",
 	"parentB": "",
-	"enabled": true
+	"enabled": false
 }

--- a/src/main/resources/data/crimsonchickens/configs/modded/enderium.json
+++ b/src/main/resources/data/crimsonchickens/configs/modded/enderium.json
@@ -18,5 +18,5 @@
 	"hasTrait": 0,
 	"parentA": "",
 	"parentB": "",
-	"enabled": true
+	"enabled": false
 }

--- a/src/main/resources/data/crimsonchickens/configs/modded/osmium.json
+++ b/src/main/resources/data/crimsonchickens/configs/modded/osmium.json
@@ -1,6 +1,6 @@
 {
 	"displayName": "Osmium Chicken",
-	"dropItem": "mekanism:ingot_osmium",
+	"dropItem": "items:c:osmium_ingots",
 	"dropItemNBT": "",
 	"spawnNaturally": false,
 	"spawnType": 1,

--- a/src/main/resources/data/crimsonchickens/configs/modded/signalum.json
+++ b/src/main/resources/data/crimsonchickens/configs/modded/signalum.json
@@ -18,5 +18,5 @@
 	"hasTrait": 0,
 	"parentA": "",
 	"parentB": "",
-	"enabled": true
+	"enabled": false
 }

--- a/src/main/resources/data/crimsonchickens/configs/modded/uraninite.json
+++ b/src/main/resources/data/crimsonchickens/configs/modded/uraninite.json
@@ -18,5 +18,5 @@
 	"hasTrait": 9,
 	"parentA": "",
 	"parentB": "",
-	"enabled": true
+	"enabled": false
 }

--- a/src/main/resources/data/crimsonchickens/configs/modded/yellorite.json
+++ b/src/main/resources/data/crimsonchickens/configs/modded/yellorite.json
@@ -18,5 +18,5 @@
 	"hasTrait": 9,
 	"parentA": "",
 	"parentB": "",
-	"enabled": true
+	"enabled": false
 }


### PR DESCRIPTION
-Changed Osmium dropItem from mekanism (not on Fabric) to tags (mythic metals)
-Disabled chickens not available on fabric: Draconium, Awakened Draconium, Uraninite, Yellorite, Enderium and Signalum
-Disabled Dust for the same reason, though it seems an exnihilo fabric version is in the works its not released yet